### PR TITLE
Tell proxy to use ssl

### DIFF
--- a/lib/replicate/object.rb
+++ b/lib/replicate/object.rb
@@ -50,7 +50,7 @@ module Replicate
     def download(location, replicated_file)
       downloaded = false
 
-      proxy.start(location.host, location.port) do |http|
+      proxy.start(location.host, location.port, :use_ssl => true) do |http|
         http.request(request(location, replicated_file)) do |response|
           if response.is_a? Net::HTTPOK
             write replicated_file, response


### PR DESCRIPTION
It appears that proxy doesn't use ssl unless you tell it to use_ssl in proxy.start.

Otherwise I get a 400 error when downloading artifacts like the following:

```
FAILURE (node/lucid/x86_64/node-0.9.11.tar.gz): Unable to download from 'https://download.run.pivotal.io/node/lucid/x86_64/node-0.9.11.tar.gz'.  Received '400'.
```
