### PR TITLE
Use a tempory file when replicating the repository

### DIFF
--- a/lib/replicate/root.rb
+++ b/lib/replicate/root.rb
@@ -77,16 +77,15 @@ module Replicate
     def process(object)
       replicated_file = ReplicatedFile.new options[:output], object.key
 
-      with_cleanup(object, replicated_file) do
+      with_cleanup(object) do
         object.replicate replicated_file
         @index_updater.update replicated_file
       end
     end
 
-    def with_cleanup(object, replicated_file)
+    def with_cleanup(object)
       yield
     rescue => e
-      replicated_file.destroy
       $stderr.print "FAILURE (#{object.key}): #{e}\n"
       raise e
     end

--- a/spec/replicate/replicated_file_spec.rb
+++ b/spec/replicate/replicated_file_spec.rb
@@ -66,22 +66,6 @@ describe Replicate::ReplicatedFile do
     end
   end
 
-  it 'should destroy cached and metadata files' do
-    Dir.mktmpdir do |root|
-      replicated_file = described_class.new root, 'foo'
-
-      replicated_file.content { |f| f.write 'test-content' }
-      replicated_file.etag          = 'test-etag'
-      replicated_file.last_modified = 'test-last-modified'
-
-      replicated_file.destroy
-
-      expect(Pathname.new(root) + 'foo').not_to exist
-      expect(Pathname.new(root) + 'foo.etag').not_to exist
-      expect(Pathname.new(root) + 'foo.last_modified').not_to exist
-    end
-  end
-
   def expect_file_content(root, name, content)
     expect((Pathname.new(root) + name).read).to match(content)
   end


### PR DESCRIPTION
When the repository is being replicated and an error occurs the local repository
is deleted. This commit causes a tempory file before moving the downloaded file
to its final location. The tempory file will be automatically cleaned up.

See: https://github.com/cloudfoundry/java-buildpack-dependency-builder/issues/9

[#78901290]
