### PR TITLE
Ensure package metadata is updated before install

### DIFF
--- a/google-stackdriver-debugger/Dockerfile
+++ b/google-stackdriver-debugger/Dockerfile
@@ -1,6 +1,6 @@
 FROM cloudfoundry/cflinuxfs2
 
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
     curl \


### PR DESCRIPTION
Our build failed recently because some packages were out of sync with the Ubuntu repositories.