### PR TITLE
Fixed Skywalking download regex

### DIFF
--- a/resources/skywalking/skywalking.go
+++ b/resources/skywalking/skywalking.go
@@ -18,17 +18,18 @@ package skywalking
 
 import (
 	"fmt"
-	"github.com/gocolly/colly"
 	"regexp"
 	"resources/check"
 	"resources/in"
 	"resources/internal"
 	"strings"
+
+	"github.com/gocolly/colly"
 )
 
 const root = "https://skywalking.apache.org/downloads"
 
-var checkPattern = internal.Pattern{Regexp: regexp.MustCompile("v([\\d]+)\\.([\\d]+)\\.([\\d]+) for ElasticSearch 6")}
+var checkPattern = internal.Pattern{Regexp: regexp.MustCompile("v([\\d]+)\\.([\\d]+)\\.([\\d]+)")}
 
 type SkyWalking struct {
 	Version internal.Version `json:"version"`


### PR DESCRIPTION
The HTML title for the download object has changed and the CI is broken, this fixes the regex that matches on the title.