### PR TITLE
Adjust selector for picking the Java agent specificall

### DIFF
--- a/resources/skywalking/skywalking.go
+++ b/resources/skywalking/skywalking.go
@@ -29,7 +29,7 @@ import (
 
 const root = "https://skywalking.apache.org/downloads"
 
-var checkPattern = internal.Pattern{Regexp: regexp.MustCompile("v([\\d]+)\\.([\\d]+)\\.([\\d]+)")}
+var checkPattern = internal.Pattern{Regexp: regexp.MustCompile(`v([\d]+)\.([\d]+)\.([\d]+)`)}
 
 type SkyWalking struct {
 	Version internal.Version `json:"version"`
@@ -41,11 +41,16 @@ func (s SkyWalking) Check() (check.Result, error) {
 	c := colly.NewCollector()
 
 	// fixme: this selector is probably fragile
-	c.OnHTML(".dropdown-header", func(e *colly.HTMLElement) {
-		_ = checkPattern.IfMatches(e.Text, func(g []string) error {
-			result.Add(internal.Version{Ref: fmt.Sprintf("%s.%s.%s", g[1], g[2], g[3])})
-			return nil
-		})
+	// make sure to grab the java agent, not one of the other downloads on that page
+	c.OnHTML(".card-body", func(e *colly.HTMLElement) {
+		if e.ChildText(".title-box > .card-title") == "SkyWalking Java Agent" {
+			version := e.ChildText(".dropdown-header")
+
+			_ = checkPattern.IfMatches(version, func(g []string) error {
+				result.Add(internal.Version{Ref: fmt.Sprintf("%s.%s.%s", g[1], g[2], g[3])})
+				return nil
+			})
+		}
 	})
 
 	err := c.Visit(root)
@@ -71,14 +76,14 @@ func (s SkyWalking) In(destination string) (in.Result, error) {
 	return in.Result{
 		Version: s.Version,
 		Metadata: []in.Metadata{
-			{"uri", uri},
-			{"sha256", sha256},
+			{Name: "uri", Value: uri},
+			{Name: "sha256", Value: sha256},
 		},
 	}, nil
 }
 
 func (s SkyWalking) name() string {
-	return fmt.Sprintf("apache-skywalking-apm-%s.tar.gz", s.Version.Ref)
+	return fmt.Sprintf("apache-skywalking-java-agent-%s.tar.gz", s.Version.Ref)
 }
 
 func (s SkyWalking) uri() (string, error) {
@@ -89,7 +94,7 @@ func (s SkyWalking) uri() (string, error) {
 		u = strings.TrimSpace(e.Text)
 	})
 
-	if err := c.Visit(fmt.Sprintf("https://www.apache.org/dyn/closer.cgi/skywalking/%[1]s/apache-skywalking-apm-%[1]s.tar.gz", s.Version.Ref)); err != nil {
+	if err := c.Visit(fmt.Sprintf("https://www.apache.org/dyn/closer.cgi/skywalking/java-agent/%[1]s/apache-skywalking-java-agent-%[1]s.tgz", s.Version.Ref)); err != nil {
 		return "", err
 	}
 

--- a/sky-walking.sh
+++ b/sky-walking.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 
 VERSION=$(cat sky-walking-archives/version)
 
-cp sky-walking-archives/apache-skywalking-apm-*.tar.gz repository/sky-walking-$VERSION.tar.gz
+cp sky-walking-archives/apache-skywalking-java-agent-*.tar.gz repository/sky-walking-$VERSION.tar.gz
 cp sky-walking-archives/version repository/version


### PR DESCRIPTION
Previously it was picking the first version it found, which was for the Skywalking server. We want to make sure it picks the Java agent which has a separate version.