### PR TITLE
Support using different file extensions for AppDyanmics

### DIFF
--- a/appdynamics.sh
+++ b/appdynamics.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 VERSION=$(cat appdynamics-archives/version)
+EXT=$(cat appdynamics-archives/extension)
 
-cp appdynamics-archives/appdynamics_linux_*.tar.gz repository/appdynamics-$VERSION.tar.gz
+cp appdynamics-archives/appdynamics_linux_*.$EXT "repository/appdynamics-$VERSION.$EXT"
 cp appdynamics-archives/version repository/version


### PR DESCRIPTION
The AppDynamics downloads for Java & PHP have different file extensions/compression methods. Previously the pipeline would assume that they were all 'tar.gz', which works for the Java agent. The PHP agent is 'tar.bz2'. This change adds support for different file extensions. It is mapped via the type defined in the resource source configuration.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>