### PR TITLE
Take version from redisson-all-archives

### DIFF
--- a/redisson.sh
+++ b/redisson.sh
@@ -8,4 +8,4 @@ cp redisson-all-archives/redisson-all-*.jar repository/redisson-all-$VERSION.jar
 cp redisson-tomcat-8-archives/redisson-tomcat-8-*.jar repository/redisson-tomcat-8-$VERSION.jar
 cp redisson-tomcat-9-archives/redisson-tomcat-9-*.jar repository/redisson-tomcat-9-$VERSION.jar
 cp redisson-tomcat-10-archives/redisson-tomcat-10-*.jar repository/redisson-tomcat-10-$VERSION.jar
-cp redisson-archives/version repository/version
+cp redisson-all-archives/version repository/version


### PR DESCRIPTION
The version number should match across all the redisson repos, so it doesn't really matter which one we pick.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>