### PR TITLE
Add Java 25 support

### DIFF
--- a/openjdk25.sh
+++ b/openjdk25.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cp jdk-25/bellsoft-jdk*.tar.gz images
+cp jre-25/bellsoft-jre*.tar.gz images
+
+PATTERN="([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)"
+if [[ $(cat jdk-25/version) =~ ${PATTERN} ]]; then
+  echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}-${BASH_REMATCH[4]}" > images/version
+else
+  echo "version is not semver" 1>&2
+  exit 1
+fi


### PR DESCRIPTION
Added [openjdk25.sh](https://github.com/boisvertmathieu/java-buildpack-dependency-builder/blob/3002c92b9d2d079a559cc8d08920c8053a033571/openjdk25.sh) script to support Java 25 dependency artifacts, following the same pattern as [openjdk21.sh](https://github.com/cloudfoundry/java-buildpack-dependency-builder/blob/main/openjdk21.sh)

Related to issue https://github.com/cloudfoundry/java-buildpack-dependency-builder/issues/79